### PR TITLE
V13 Werewolf to Human Updates

### DIFF
--- a/modules/shape-changer.js
+++ b/modules/shape-changer.js
@@ -387,7 +387,9 @@ export class ShapeChanger {
             "cannot-speak",
             "speed",
             "regeneration-slow",
-            "infravision"
+            "infravision",
+            "ferocity",
+            "weakness"
         ];
 
         let itemsToRemove = [];
@@ -417,9 +419,6 @@ export class ShapeChanger {
         //Werewolves increase agility, strength and vigor by 2 die types so we need to remove that
         let actorUpdateData = {
             name: originalActor.name,
-            "system.attributes.agility.die.sides": originalActor._source.system.attributes.agility.die.sides - 4,
-            "system.attributes.strength.die.sides": originalActor._source.system.attributes.strength.die.sides - 4,
-            "system.attributes.vigor.die.sides": originalActor._source.system.attributes.vigor.die.sides - 4,
             "system.details.autoCalcToughness": true //In the off chance this was disabled, we need to enable it so the human form is correct
         };
 

--- a/modules/shape-changer.js
+++ b/modules/shape-changer.js
@@ -362,6 +362,7 @@ export class ShapeChanger {
             x: originalTokenDoc.x,
             y: originalTokenDoc.y,
             "sight.enabled": originalTokenDoc.sight.enabled,
+            "sight.visionMode": "basic", // Humans only have basic vision. This allows the werewolf token to have infravision enabled
             actorLink: false, //We always want to unlink the actor so that we don't modify the original
             "texture.src": humanTokenImg,
             "texture.scaleX": humanTokenScale,
@@ -428,8 +429,6 @@ export class ShapeChanger {
         for (let item of itemsToRemove) {
             await item.delete();
         }
-
-        // Todo: revert token vision back to basic. Only werewolves have infravision.
 
         // Update the name
         let actorUpdateData = {

--- a/modules/shape-changer.js
+++ b/modules/shape-changer.js
@@ -392,21 +392,34 @@ export class ShapeChanger {
             "weakness"
         ];
 
+        const WEREWOLF_WEAPONS = [
+            "natural-bite",
+            "natural-claws"
+        ];
+
         let itemsToRemove = [];
         for (let item of createdActor.items) {
             if (item.type == "edge") {
-                //Werewolves do not keep their werewolf edges in human form
+                // Werewolves do not keep their werewolf edges in human form
                 if (item.system.requirements.find((r) => r.selector == "werewolf")){
                     itemsToRemove.push(item);
                 }
             } else if (item.type == "ability") {
-                //Werewolves do not keep their werewolf abilities in human form
+                // Werewolves do not keep their werewolf abilities in human form
                 if (WEREWOLF_ABILITIES.find((a) => a == item.system.swid)) {
                     itemsToRemove.push(item);
                 }
             } else if (item.type == "hindrance") {
-                //Werewolves only have the weakness to silvered weapons while in werewolf form
+                // Werewolves only have the weakness to silvered weapons while in werewolf form
+                // This does not appear to be required on v13, but leaving it here doesn't appear to hurt.
                 if (item.name.toLowerCase().includes("weakness") && item.system.description.toLowerCase().includes("silvered weapons")) {
+                    itemsToRemove.push(item);
+                }
+            }
+            else if (item.type == "weapon") {
+                // Werewolves do not keep their werewolf weapons in human form
+                // This is required as removing the "Bite/Claws" ability does not remove the associated bite and claw weapons from inventory
+                if (WEREWOLF_WEAPONS.find((a) => a == item.system.swid)) {
                     itemsToRemove.push(item);
                 }
             }
@@ -416,7 +429,9 @@ export class ShapeChanger {
             await item.delete();
         }
 
-        //Werewolves increase agility, strength and vigor by 2 die types so we need to remove that
+        // Todo: revert token vision back to basic. Only werewolves have infravision.
+
+        // Update the name
         let actorUpdateData = {
             name: originalActor.name,
             "system.details.autoCalcToughness": true //In the off chance this was disabled, we need to enable it so the human form is correct


### PR DESCRIPTION
I've made some updates to the werewolf to human functionality to overcome issues that I was seeing when running in the following setup:

- Foundry 13.345
- SWADE 5.0.3
- SWADE Core Rules 13.0.0
- SWADE Horror Companion 13.0.0
- SWADE Shape Changer 1.0.2

Issues fixed:

- The human token attributes after the change were too low, because the module is updating the attributes twice. In v13, removing the Ferocity ability automatically reverts the attribute changes, so manually adjusting attributes isn't required. 
- Ferocity and Weakness abilities are removed from the human form.
- Bite and claw natural weapons are removed from human form.
- Human form vision is set to `basic`. This allows the werewolf form to have a limited ability to see heat enabled in alignment with the werewolf rules, and it will be disabled on the human form.

I've tested and everything appears to be working.